### PR TITLE
Improve test messages

### DIFF
--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -28,14 +28,31 @@ class IntegrityTestCase(unittest.TestCase):
             with self.subTest(name=path.name):
                 stem = path.stem
                 norm_stem = bioregistry.normalize_prefix(stem)
-                self.assertEqual(norm_stem, stem, msg=f"unnormalized file name: {path.name}")
+                self.assertIsNotNone(
+                    norm_stem,
+                    msg=f"The Bioregistry does not contain an entry for {stem}. Please consider "
+                    f"submitting a new prefix request at https://github.com/biopragmatics/bioregistry/"
+                    f"issues/new?assignees=biopragmatics%2Fbioregistry-reviewers&labels=New%2CPrefix&"
+                    f"template=new-prefix.yml&title=Add+prefix+%5B{stem}%5D.",
+                )
+                self.assertEqual(
+                    norm_stem,
+                    stem,
+                    msg=f"The file name {path.name} is not normalized to the Bioregistry "
+                    f"standard. Please rename this file to {norm_stem}.tsv",
+                )
 
     def test_csv_integrity(self):
         """Test all files have the right columns."""
         for path in self.paths:
             prefix = path.stem
             pattern = bioregistry.get_pattern(prefix)
-            self.assertIsNotNone(pattern)
+            self.assertIsNotNone(
+                pattern,
+                msg=f"The Bioregistry does not contain a regular expression pattern for validating identifiers "
+                f"from {prefix}. Please consider submitting an issue on the Bioregistry to add one at "
+                "https://github.com/biopragmatics/bioregistry/issues.",
+            )
             pattern_re = re.compile(pattern)
 
             with self.subTest(name=path.name), path.open() as file:
@@ -52,7 +69,9 @@ class IntegrityTestCase(unittest.TestCase):
                         try:
                             old_id, date, new_id = line.split("\t")
                         except ValueError:
-                            self.fail(f"{path.name} had wrong number of columns on line {i}")
+                            self.fail(
+                                f"{path.name} had wrong number of columns on line {i}"
+                            )
                         if date:
                             self.assertRegex(date, DATE_RE)
                         self.assertRegex(

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -51,7 +51,8 @@ class IntegrityTestCase(unittest.TestCase):
                 pattern,
                 msg=f"The Bioregistry does not contain a regular expression pattern for validating identifiers "
                 f"from {prefix}. Please consider submitting an issue on the Bioregistry to add one at "
-                "https://github.com/biopragmatics/bioregistry/issues.",
+                f"https://github.com/biopragmatics/bioregistry/issues/new?assignees=cthoyt&labels=Regex%2C"
+                f"Update&template=update-regex.yml&title=Update+regular+expression+pattern+for+%5B{prefix}%5D.",
             )
             pattern_re = re.compile(pattern)
 


### PR DESCRIPTION
This PR improves messages thrown by the testing framework in three situations:

1. If the name of TSV file is not corresponding to an existing prefix in the Bioregistry
2. If the name of a TSV file is not a *canonical* prefix in the Bioregistry
3. If there is no pattern available in the Bioregistry, suggests adding one through the GitHub issue tracker